### PR TITLE
update poetry to 1.4.2

### DIFF
--- a/.environment
+++ b/.environment
@@ -1,3 +1,3 @@
 # Updates PATH when Poetry is used, making it available during deploys and SSH.
-export POETRY_VERSION='1.1.14'
+export POETRY_VERSION='1.4.2'
 export PATH="/app/.local/bin:$PATH"


### PR DESCRIPTION
## Description
Updates are failing due to poetry being out-of-date. This upgrades the version of poetry to 1.4.2